### PR TITLE
Create file types to support multiple date based names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
+target/
 Cargo.lock

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ See `zk --help` for help.
 
 ### Creating notes
 
-1. Use `zk` opens new note in editor (default: vim)
+1. Use `zk` opens new note in EDITOR (default: vim)
 
 2. Add note inline as a command-line argument
 ```
@@ -28,26 +28,24 @@ $ git log -1 | zk
 $ zk < file-to-import.txt
 ```
 
-You can create a tag using @tag which can then be used to search later.
-```
-$ zk "Here is my note with a @tag"
-```
+### Types of Notes
 
-### Viewing Notes
+There are five types of notes: default, monthly, weekly, daily, new.
 
-What view features?
+The note type is specified by using the related command-line flag (`--monthly` `--weekly` `--daily` or `--new`).  The default note is created when no flag is present.
 
-- Search
-- By Date
-- By Tag
+The default file names per type is:
 
+| Type              | Format String   | Example           |
+| monthly_format	| %Y-%m-%b.md     | 2021-02-Feb.md    |
+| weekly_format     | %Y-week-%U.md   | 2021-week-08.md   |
+| daily_format      | %Y-%m-%d.md     | 2021-02-25.md     |
+| new_format        | %Y%m%d%H%M%S.md | 20210225153423.md |
+| default_format    | %Y%m%d%H%M.md   | 202102251534.md   |
 
-### Editing Notes
+See [Chrono strftime documentation](https://docs.rs/chrono-wasi/0.4.10/chrono/format/strftime/index.html) for format parameters.
 
-What edit features?
-
-- Add `--edit` to a view
-- Use menu to select results
+If the file does not exist, it will be created, otherwise opened or appended to.
 
 ## Configuration
 
@@ -59,7 +57,9 @@ The config file location be be specified various ways, zk will look for the foll
 
 2. Environment variable: `ZK_CONFIG_FILE`
 
-3. Look for `${XDG_CONFIG_HOME}/zk.conf`
+3. Look for platform config directory
+a) Linux: `${XDG_CONFIG_HOME}/zk.conf`
+b) Windows: `${APPDATA}/zk.conf`
 
 4. Look for `${HOME}/.config/zk.conf`
 
@@ -71,12 +71,23 @@ The config file is in TOML format, example:
 # zk config file
 
 # base directory that all zks are stored
-notes_dir = '~/Documents/Zks'
+notes_dir = '~/Documents/Zettelkasten'
 
-# What timestamp to use for default notes
-# This allow you to create monthly, weekly, or daily notes.
+# What format to use for notes
 # See: https://docs.rs/chrono/0.4.0/chrono/format/strftime/index.html
-filename_format = '%y%m%d%H%M.md'
+default_format = '%Y%m%d%H%M.md'
+
+# 2021-02-Feb.md
+monthly_format="%Y-%m-%b.md"
+
+# 2021-week-08.md
+weekly_format="%Y-week-%U.md"
+
+# 2021-02-25.md
+daily_format="%Y-%m-%d.md"
+
+# 20210225153423.md
+new_format="%Y%m%d%H%M%S.md"
 ```
 
 ## Errata

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,12 +7,41 @@ use toml;
 #[derive(Clone, Deserialize)]
 pub struct Config {
     pub notes_dir: String,
+
     #[serde(default = "default_format")]
-    pub filename_format: String,
+    pub default_format: String,
+
+    #[serde(default = "monthly_format")]
+    pub monthly_format: String,
+
+    #[serde(default = "weekly_format")]
+    pub weekly_format: String,
+
+    #[serde(default = "daily_format")]
+    pub daily_format: String,
+
+    #[serde(default = "new_format")]
+    pub new_format: String,
 }
 
 fn default_format() -> String {
     "%Y%m%d%H%M.md".to_string()
+}
+
+fn monthly_format() -> String {
+    "%Y-%m-%b.md".to_string()
+}
+
+fn weekly_format() -> String {
+    "%Y-week-%U.md".to_string()
+}
+
+fn daily_format() -> String {
+    "%Y-%m-%d.md".to_string()
+}
+
+fn new_format() -> String {
+    "%Y%m%d%H%M%S.md".to_string()
 }
 
 pub fn get_config(filearg: Option<&str>) -> Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ fn main() {
     let mut content = String::new();
 
     // get new filename
-    let filename = utils::get_new_filename(args, config);
+    let filename = utils::get_new_filename(args.clone(), config.clone());
     let file_path = notes_path.join(filename);
 
     // get file content from pipe

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,10 @@ fn main() {
                 .long("config")
                 .takes_value(true),
         )
+        .arg(Arg::new("monthly").about("Monthly note").long("monthly"))
+        .arg(Arg::new("weekly").about("Weekly note").long("weekly"))
+        .arg(Arg::new("daily").about("Daily note").long("daily"))
+        .arg(Arg::new("new").about("New note").long("new"))
         .arg(
             Arg::new("content")
                 .about("Create note from command-line")
@@ -55,7 +59,7 @@ fn main() {
     let mut content = String::new();
 
     // get new filename
-    let filename = utils::get_new_filename(config.filename_format);
+    let filename = utils::get_new_filename(args, config);
     let file_path = notes_path.join(filename);
 
     // get file content from pipe

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,8 +11,17 @@ pub fn get_new_filename(args: ArgMatches, config: super::config::Config) -> Stri
     // determine if monthly, weekly, daily, new or default
     let now: DateTime<Utc> = Utc::now();
 
-    if args.is_present("monthly") {
-        config.
-    }
+    let format = if args.is_present("monthly") {
+        config.monthly_format
+    } else if args.is_present("weekly") {
+        config.weekly_format
+    } else if args.is_present("daily") {
+        config.daily_format
+    } else if args.is_present("new") {
+        config.new_format
+    } else {
+        config.default_format
+    };
+
     now.format(&format).to_string()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,12 +1,18 @@
 use atty::Stream;
 use chrono::{DateTime, Utc};
+use clap::ArgMatches;
 
 pub fn is_pipe() -> bool {
     !atty::is(Stream::Stdin)
 }
 
 // generate filename from date/time
-pub fn get_new_filename(format: String) -> String {
+pub fn get_new_filename(args: ArgMatches, config: super::config::Config) -> String {
+    // determine if monthly, weekly, daily, new or default
     let now: DateTime<Utc> = Utc::now();
+
+    if args.is_present("monthly") {
+        config.
+    }
     now.format(&format).to_string()
 }


### PR DESCRIPTION
Adds the following flags and default formats for creating different files

|Flag   | Config              | Format String   | Example           |
|--------|---------------------|----------------------|----------------------|
|--monthly | monthly_format	| %Y-%m-%b.md     | 2021-02-Feb.md    |
|--weekly | weekly_format     | %Y-week-%U.md   | 2021-week-08.md   |
|--daily | daily_format      | %Y-%m-%d.md     | 2021-02-25.md     |
|--new | new_format        | %Y%m%d%H%M%S.md | 20210225153423.md |
| | default_format    | %Y%m%d%H%M.md   | 202102251534.md   |